### PR TITLE
Clean up listeners for chapters-track-menu-item when dispose is called.

### DIFF
--- a/src/js/control-bar/text-track-controls/chapters-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/chapters-track-menu-item.js
@@ -34,7 +34,11 @@ class ChaptersTrackMenuItem extends MenuItem {
 
     this.track = track;
     this.cue = cue;
-    track.addEventListener('cuechange', Fn.bind(this, this.update));
+
+    const updateInstance = Fn.bind(this, this.update);
+
+    track.addEventListener('cuechange', updateInstance);
+    this.on('dispose', () => track.removeEventListener('cuechange', updateInstance));
   }
 
   /**


### PR DESCRIPTION
## Description
On dispose clean up the update listener otherwise on 'cuechange' event the update listener will be called on already disposed classes

## Specific Changes proposed
Add a dispose listener to remove the update listener from the 'cuechange'  event